### PR TITLE
데이터베이스 객체 추상화와 ViewModel 테스트

### DIFF
--- a/Bitnote/BitnoteTests/BitnoteTests.swift
+++ b/Bitnote/BitnoteTests/BitnoteTests.swift
@@ -52,6 +52,39 @@ class BitnoteTests: XCTestCase {
         XCTAssertEqual(mockRepository.addGroupMethodCallCount, 1)
         XCTAssertEqual(mockRepository.groupList.count, 4)
     }
+    
+    func test_GroupListViewModel_whenEditGroupTitle_matchTitle() {
+        // given
+        mockRepository.groupList = [Group(title: "NewGroup")]
+        
+        // when
+        let indexPath = IndexPath(row: 0, section: 0)
+        let group = sut.getGroup(by: indexPath)
+        XCTAssertNotNil(group)
+        
+        let editTitle = "Edited!"
+        sut.editGroupTitle(group!, title: editTitle)
+        
+        // then
+        XCTAssertEqual(mockRepository.editGroupTitleMethodCallCount, 1)
+        
+        let editedGroup = sut.getGroup(by: indexPath)
+        XCTAssertNotNil(editedGroup)
+        XCTAssertEqual(editedGroup!.title, editTitle)
+    }
+    
+    func test_GroupListViewModel_whenDeleteGroup() {
+        // given
+        mockRepository.groupList = [Group(title: "NewGroup")]
+        let indexPath = IndexPath(row: 0, section: 0)
+        
+        // when
+        sut.deleteGroup(at: indexPath.row)
+        
+        // then
+        XCTAssertEqual(mockRepository.deleteGroupMethodCallCount, 1)
+        XCTAssertNil(sut.getGroup(by: indexPath))
+    }
 }
 
 
@@ -73,9 +106,9 @@ class MockRepository: Repository {
         return items
     }
     
-    func getGroup(by indexPath: IndexPath) -> Group {
+    func getGroup(at index: Int) -> Group? {
         getGroupMethodCallCount += 1
-        return groupList[indexPath.row]
+        return groupList[safe: index]
     }
     
     func fetchGroups(completion: @escaping ([Group]) -> Void) {

--- a/Bitnote/DeveloperNote.xcodeproj/project.pbxproj
+++ b/Bitnote/DeveloperNote.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		98AE615E295C546F008E8938 /* Persistable+Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6156295C5378008E8938 /* Persistable+Group.swift */; };
 		98AE615F295C5472008E8938 /* Persistable+Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE615B295C53EA008E8938 /* Persistable+Log.swift */; };
 		98AE6160295C5503008E8938 /* SettingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F73FE44260CEE7D00FADE98 /* SettingConfig.swift */; };
+		98AE6162295D9769008E8938 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6161295D9768008E8938 /* Collection+Extensions.swift */; };
+		98AE6163295D9771008E8938 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6161295D9768008E8938 /* Collection+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -278,6 +280,7 @@
 		98AE6156295C5378008E8938 /* Persistable+Group.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Persistable+Group.swift"; sourceTree = "<group>"; };
 		98AE6158295C53B4008E8938 /* Persistable+Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Persistable+Note.swift"; sourceTree = "<group>"; };
 		98AE615B295C53EA008E8938 /* Persistable+Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Persistable+Log.swift"; sourceTree = "<group>"; };
+		98AE6161295D9768008E8938 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
 		A276393FFD15E2D49AAB78FA /* Pods-DeveloperNote-BitnoteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DeveloperNote-BitnoteTests.debug.xcconfig"; path = "Target Support Files/Pods-DeveloperNote-BitnoteTests/Pods-DeveloperNote-BitnoteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C10E2E925BB96562D695FAE3 /* Pods-DeveloperNote-BitnoteTests.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DeveloperNote-BitnoteTests.beta.xcconfig"; path = "Target Support Files/Pods-DeveloperNote-BitnoteTests/Pods-DeveloperNote-BitnoteTests.beta.xcconfig"; sourceTree = "<group>"; };
 		C8E7C1A49B8D3616317C8B54 /* Pods-DeveloperNote-BitnoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DeveloperNote-BitnoteTests.release.xcconfig"; path = "Target Support Files/Pods-DeveloperNote-BitnoteTests/Pods-DeveloperNote-BitnoteTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -342,6 +345,7 @@
 			isa = PBXGroup;
 			children = (
 				6F37D73926E0F38D00243B43 /* Locale.swift */,
+				98AE6161295D9768008E8938 /* Collection+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1036,6 +1040,7 @@
 				6F6F7539260A6BC000390952 /* SwitchButtonCell.swift in Sources */,
 				6FFD1E8824AE4BB5008A52E5 /* Group.swift in Sources */,
 				6F655D3D24D1B9B300402868 /* NoteListViewModel.swift in Sources */,
+				98AE6162295D9769008E8938 /* Collection+Extensions.swift in Sources */,
 				6F655D3B24D14A0D00402868 /* GroupListViewModel.swift in Sources */,
 				6F655D2024CDBF1900402868 /* NoteDrawingViewController.swift in Sources */,
 				6F3C915F26D595E000035683 /* BlinkPageViewController.swift in Sources */,
@@ -1066,6 +1071,7 @@
 				98AE6155295C530D008E8938 /* Log.swift in Sources */,
 				981F04B8295C28130023D345 /* BitnoteTests.swift in Sources */,
 				98AE6160295C5503008E8938 /* SettingConfig.swift in Sources */,
+				98AE6163295D9771008E8938 /* Collection+Extensions.swift in Sources */,
 				981F04C3295C41EF0023D345 /* Repository.swift in Sources */,
 				98AE6153295C4B52008E8938 /* Group.swift in Sources */,
 			);

--- a/Bitnote/DeveloperNote/Group/GroupListViewController.swift
+++ b/Bitnote/DeveloperNote/Group/GroupListViewController.swift
@@ -56,7 +56,9 @@ class GroupListViewController: AdsBaseViewController {
             let selectedCell = sender as? GroupListCell,
             let selectedIndexPath = tableView.indexPath(for: selectedCell)
         {
-            let group = self.viewModel.getGroupByIndexPath(selectedIndexPath)
+            guard let group = self.viewModel.getGroup(by: selectedIndexPath) else {
+                return
+            }
             let noteListViewModel = NoteListViewModel(group)
             notelistVC.viewModel = noteListViewModel
         }
@@ -140,7 +142,7 @@ extension GroupListViewController: UITableViewDelegate {
      * 3. 테이블 뷰 갱신
      */
     private func handleEditCategory(_ indexPath: IndexPath) -> Bool {
-        let selectedGroup = viewModel.getGroupByIndexPath(indexPath)
+        let selectedGroup = viewModel.getGroup(by: indexPath)
         
         let vc = GroupAddViewController(selectedGroup: selectedGroup)
         vc.delegate = self

--- a/Bitnote/DeveloperNote/Group/GroupListViewModel.swift
+++ b/Bitnote/DeveloperNote/Group/GroupListViewModel.swift
@@ -47,8 +47,8 @@ class GroupListViewModel {
     }
     
     
-    func getGroupByIndexPath(_ indexPath: IndexPath) -> Group {
-        return repository.getGroup(by: indexPath)
+    func getGroup(by indexPath: IndexPath) -> Group? {
+        return repository.getGroup(at: indexPath.row)
     }
     
     

--- a/Bitnote/DeveloperNote/Repository/GroupRepository.swift
+++ b/Bitnote/DeveloperNote/Repository/GroupRepository.swift
@@ -5,8 +5,8 @@ class GroupRepository: Repository {
 
     private var groupDataList: [Group] = []
     
-    func getGroup(by indexPath: IndexPath) -> Group {
-        return groupDataList[indexPath.row]
+    func getGroup(at index: Int) -> Group? {
+        return groupDataList[safe: index]
     }
     
     func fetchGroups(completion: @escaping ([Group]) -> Void) {

--- a/Bitnote/DeveloperNote/Repository/Repository.swift
+++ b/Bitnote/DeveloperNote/Repository/Repository.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol Repository {
-    func getGroup(by indexPath: IndexPath) -> Group
+    func getGroup(at index: Int) -> Group?
     func fetchGroups(completion: @escaping ([Group]) -> Void)
     func addGroup(title: String, completion: @escaping ([Group]?) -> Void)
     func deleteGroup(row: Int, completion: @escaping ([Group]?) -> Void)

--- a/Bitnote/DeveloperNote/Utils/Collection+Extensions.swift
+++ b/Bitnote/DeveloperNote/Utils/Collection+Extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Collection where Indices.Iterator.Element == Index {
+   public subscript(safe index: Index) -> Iterator.Element? {
+     return (startIndex <= index && index < endIndex) ? self[index] : nil
+   }
+}


### PR DESCRIPTION
## 키워드
- `Unit Test`[^1]
- `Test double type`[^2]

## 📚 작업
- [x] Repository protocol 를 사용한 추상화
- [x] 유닛 테스트를 하기위해 가짜 객체인 MockRepository 구현
- [x] 그룹리스트 화면의 ViewModel 테스트

## 참고) 수정 전 구조

<img src="https://user-images.githubusercontent.com/12508578/210141429-2f4c8d97-df70-4bc3-88fd-560cce8bca62.jpg" width="200px"/>


## 🌤 고민과 해결
### 1. 어디부터 테스트를 해야 하는가

**`고민`**
잘 못 수정할 경우 사이드이펙트가 염려 되었으므로 신중하게 접근해야 했다. 

**`해결`**
도식화를 통해 각 화면을 기준으로 View,ViewModel,Database 를 사용하는 패턴이 동일하다는 것을 파악했다. 
기능이 단순하다고 판단되는 Group화면에 대한 로직을 먼저 테스트 하기로 결정내렸다.

RealmManager 에 변경사항을 최소화하기 위해서, 이를 사용하는 Repository 계층을 추가했다. 
Repository 는 저장소에 대한 CRUD 작업을 담당하는 객체로, 그 저장소가 무엇이든(Realm, Coredata...) 상관없이 동작하도록 하고 싶었다. 
이제 ViewModel 은 Repository 에 대해서만 알면되므로, 구체적으로 어떤 데이터베이스를 사용하든지 몰라도 된다. 
=> ViewModel 의 테스트시 RealmManager 를 배제할 수 있게되었다.

_RealmManager 의 경우, 싱글톤으로 구현되어 있으므로 이를 분리하는 작업에 대한 고민이 추가적으로 필요하다._

<img src="https://user-images.githubusercontent.com/12508578/210138335-38063493-4440-4684-a00c-5172746c16cd.jpg" width="300px"/>

### 2. 테스트를 어떻게 해야 하는가...?
**`고민`**
이제까지 해왔던 unit test 는 가장 작은 단위로만 진행했으므로, 신경쓸 부분이 작았다. 하지만 테스트하고자 하는 대상인 ViewModel 인 경우, 내부 인스턴스를 가지므로 어떻게 객체간의 상호작용을 테스트 해야하는지 어려웠다. 서치를 통해 의존성이 있는 대상을 테스트할때는 Test double type(테스트 대역 타입) 들을 활용한다는 것을 알았다. 

**`해결`**

- 기존의 ViewModel 은 싱글톤 데이터베이스를 사용했는데, 이는 객체간 관계를 파악하기 어려우므로 이니셜라이즈를 통해 주입받도록 변경했다. 
- 실제 데이터베이스를 사용하는 것은 비용이 크다고 생각이 들었기때문에, 데이터베이스의 CRUD 를 흉내내는 가짜 객체를 만들어 ViewModel 을 테스트 했다.
- ViewModel 을 테스트하기 위해 사용한 MockRepository 의 경우 Test double 중 `Fake` 라고 할 수 있지만,  행위 검증도 하므로 Mock 이라고도 할 수 있을듯 하다. 

![2 테스트적용후-testflow2](https://user-images.githubusercontent.com/12508578/209956120-251ffc63-5b18-4c9f-a2cf-2e614d263f95.jpg)

[^1]: 테스트 피라미드중 가장 하층에 위치. 가장 작은 단위의 테스트로, 3가지의 테스트중 가장 비용이 적게들고 빠르게 수행이 가능하다. 
[^2]: 의존성이 있는 객체를 테스트할때 사용되는 타입들. Dummy, Stub, Spy, Mock, Fake 가 있다. 테스트에서 부작용을 발생시키지 않으려면, 적합한 Test double(테스트 대역)을 선택하는 것이 중요하다.