### PR TITLE
Group을 DB에 저장하는 로직을 리펙토링하기

### DIFF
--- a/Bitnote/BitnoteTests/BitnoteTests.swift
+++ b/Bitnote/BitnoteTests/BitnoteTests.swift
@@ -129,14 +129,19 @@ class MockRepository: Repository {
         completion(groupList)
     }
     
-    func editGroupTitle(target group: Group, title: String, completion: @escaping ([Group]?) -> Void) {
+    func editGroup(target id: UID, editTitle: String, completion: @escaping ([Group]?) -> Void) {
         editGroupTitleMethodCallCount += 1
-        guard let index = groupList.firstIndex(where: { $0.id == group.id }) else {
+        guard let index = groupList.firstIndex(where: { $0.id == id }) else {
             completion(nil)
             return
         }
+        guard let originalIndex = groupList.firstIndex(where: { $0.id == id }) else {
+            completion(nil)
+            return
+        }
+        let originalGroup = groupList[originalIndex]
         groupList.remove(at: index)
-        let updateGroup = Group(original: group, uptatedTitle: title)
+        let updateGroup = Group(id: originalGroup.id, title: editTitle, notelist: originalGroup.notelist)
         groupList.insert(updateGroup, at: index)
     }
 }

--- a/Bitnote/DeveloperNote.xcodeproj/project.pbxproj
+++ b/Bitnote/DeveloperNote.xcodeproj/project.pbxproj
@@ -121,8 +121,8 @@
 		9832394529607C18007D627E /* SettingsListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9832394429607C18007D627E /* SettingsListCell.swift */; };
 		9832394C29607CC3007D627E /* NoteDrawingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9832394A29607CC3007D627E /* NoteDrawingViewController.xib */; };
 		9832394D29607CC3007D627E /* NoteDrawingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9832394B29607CC3007D627E /* NoteDrawingViewController.swift */; };
-		9832394E29607E11007D627E /* FindGroupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC1DA5B2601266A006AF877 /* FindGroupViewModel.swift */; };
 		98323954296082F1007D627E /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98323953296082F1007D627E /* ColorAssets.xcassets */; };
+		983239552961E19F007D627E /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6161295D9768008E8938 /* Collection+Extensions.swift */; };
 		98A561C92940A45B00AF6596 /* APIKeyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 98A561C82940A45B00AF6596 /* APIKeyInfo.plist */; };
 		98AE6152295C4297008E8938 /* GroupRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6151295C4297008E8938 /* GroupRepository.swift */; };
 		98AE6153295C4B52008E8938 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFD1E8724AE4BB5008A52E5 /* Group.swift */; };
@@ -1197,9 +1197,9 @@
 				98AE6155295C530D008E8938 /* Log.swift in Sources */,
 				981F04B8295C28130023D345 /* BitnoteTests.swift in Sources */,
 				98AE6160295C5503008E8938 /* SettingConfig.swift in Sources */,
-				9832394E29607E11007D627E /* FindGroupViewModel.swift in Sources */,
 				981F04C3295C41EF0023D345 /* Repository.swift in Sources */,
 				98AE6153295C4B52008E8938 /* Group.swift in Sources */,
+				983239552961E19F007D627E /* Collection+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bitnote/DeveloperNote/DB/PersistableProtocol.swift
+++ b/Bitnote/DeveloperNote/DB/PersistableProtocol.swift
@@ -11,13 +11,13 @@ import RealmSwift
 
 public protocol Persistable {
     
-    // associatedtype: 타입을 동적으로 변하게 하기위해 사용
-    // ex) name: int    -> name: T
+    /// associatedtype: 타입을 동적으로 변하게 하기위해 사용
+    /// ex) name: int    -> name: T
     associatedtype ManagedObject: RealmSwift.Object
     
-    // RealmObject -> Struct 변환
+    /// RealmObject -> Struct 변환
     init(managedObject: ManagedObject)
     
-    // Struct -> RealmObject
+    /// Struct -> RealmObject
     func managedObject() -> ManagedObject
 }

--- a/Bitnote/DeveloperNote/DB/RealmManager.swift
+++ b/Bitnote/DeveloperNote/DB/RealmManager.swift
@@ -114,6 +114,12 @@ public final class RealmManager {
         return (realm.objects(T.ManagedObject.self).max(ofProperty: "uid") as Int? ?? 0) + 1
     }
   
+    /**
+     * 사용:
+     try! manager.write { transaction in
+         transaction.add(Object)
+     }
+     */
     static func write(_ block: (WriteTransaction) throws -> Void) throws {
         guard let realm = RealmManager.realm() else {
             throw RealmErrorMessage.FailInitialize

--- a/Bitnote/DeveloperNote/DB/RealmManager.swift
+++ b/Bitnote/DeveloperNote/DB/RealmManager.swift
@@ -103,7 +103,7 @@ public final class RealmManager {
       
     public func getUrl() -> URL? {
         let url = Realm.Configuration.defaultConfiguration.fileURL
-        print("Realm Database fileUrl:", url?.absoluteString)
+        print("📂 Realm Database fileUrl:", url?.absoluteString ?? "Not Found")
         return url
     }
     
@@ -123,6 +123,24 @@ public final class RealmManager {
             try block(transaction)
         }
     }
-}
+    
+    static func fetchObjects<T: Persistable>(_ persistable: T.Type) throws -> [T] {
+        guard let realm = RealmManager.realm() else {
+            throw RealmErrorMessage.FailInitialize
+        }
+        
+        let results = realm.objects(persistable.ManagedObject)
+        return results.compactMap({ T(managedObject: $0) })
+    }
+    
+    static func editGroup<T: Persistable>(_ persistable: T.Type, targetID: UID, title: String, completion: @escaping (T) -> Void) throws {
+        guard let realm = RealmManager.realm() else {
+            throw RealmErrorMessage.FailInitialize
+        }
 
- 
+        try realm.write {
+            let updateResult = realm.create(persistable.ManagedObject, value: ["uid": targetID, "title": title], update: .modified)
+            completion(T(managedObject: updateResult))
+        }
+    }
+}

--- a/Bitnote/DeveloperNote/Model/Group.swift
+++ b/Bitnote/DeveloperNote/Model/Group.swift
@@ -24,12 +24,6 @@ struct Group {
         self.notelist = notelist
     }
     
-    /// 그룹 이름 수정할때 사용
-     init(original: Group, uptatedTitle: String){
-        self = original
-        self.title = uptatedTitle
-    }
-    
     /** 노트목록(notelist) 에서 공부할 노트만 필터해서, notelist 를 업데이트 한다
      
      - 노트 내용이 있는것

--- a/Bitnote/DeveloperNote/Repository/GroupRepository.swift
+++ b/Bitnote/DeveloperNote/Repository/GroupRepository.swift
@@ -34,24 +34,17 @@ class GroupRepository: Repository {
     }
     
     func deleteGroup(row: Int, completion: @escaping ([Group]?) -> Void) {
-        let deleteUid = groupDataList[row].id
+        let deleteUID = groupDataList[row].id
         
-        guard let realm = RealmManager.realm(),
-        let fetchGroup = realm.object(ofType: RealmGroup.self, forPrimaryKey: deleteUid) else {
-            completion(nil)
-            return
-        }
-        
-        let childObjects = fetchGroup.noteList
-        try! realm.write {
-            realm.delete(childObjects)
-            realm.delete(fetchGroup)
-            
-            groupDataList.remove(at: row)
-            completion(groupDataList)
+        do {
+            try RealmManager.deleteGroup(target: deleteUID, completion: {
+                groupDataList.remove(at: row)
+                completion(groupDataList)
+            })
+        } catch {
+            print(error.localizedDescription)
         }
     }
-
         
     func editGroup(target id: UID, editTitle: String, completion: @escaping ([Group]?) -> Void) {
         do {

--- a/Bitnote/DeveloperNote/Repository/GroupRepository.swift
+++ b/Bitnote/DeveloperNote/Repository/GroupRepository.swift
@@ -21,15 +21,15 @@ class GroupRepository: Repository {
     
     func addGroup(title: String, completion: @escaping ([Group]?) -> Void) {
         let newGroup = Group(title: title)
-        
-        guard let realm = RealmManager.realm() else {
-            completion(nil)
-            return
-        }
-        try! realm.write {
-            realm.add(newGroup.managedObject())
+
+        do {
+            try RealmManager.write { transaction in
+                transaction.add(newGroup)
+            }
             groupDataList.append(newGroup)
             completion(groupDataList)
+        } catch {
+            print(error.localizedDescription)
         }
     }
     

--- a/Bitnote/DeveloperNote/Repository/Repository.swift
+++ b/Bitnote/DeveloperNote/Repository/Repository.swift
@@ -5,5 +5,5 @@ protocol Repository {
     func fetchGroups(completion: @escaping ([Group]) -> Void)
     func addGroup(title: String, completion: @escaping ([Group]?) -> Void)
     func deleteGroup(row: Int, completion: @escaping ([Group]?) -> Void)
-    func editGroupTitle(target group: Group, title: String, completion: @escaping ([Group]?) -> Void)
+    func editGroup(target id: UID, editTitle: String, completion: @escaping ([Group]?) -> Void)
 }

--- a/Bitnote/DeveloperNote/ViewModel/Group/FindGroupViewModel.swift
+++ b/Bitnote/DeveloperNote/ViewModel/Group/FindGroupViewModel.swift
@@ -1,23 +1,20 @@
 import Foundation
 import RxSwift
 
-class FindGroupViewModel {
+final class FindGroupViewModel {
     public var groupDataList: [Group] = []
     
-    /**
-     초기화
-
-     */
     init(){
         fetchGroupFromDB()
     }
     
     func fetchGroupFromDB(){
-        if let realm = RealmManager.realm() {
-            let fetchObjects = realm.objects(RealmGroup.self)
-            self.groupDataList = fetchObjects.compactMap({ Group(managedObject: $0)})
+        
+        do {
+            let fetchResults = try RealmManager.fetchObjects(Group.self)
+            self.groupDataList = fetchResults
             
-            // todo: 학습횟수 최대 5로 설정했을때, 5이하인 노트만 가지고 온다
+            // TODO:- 학습횟수 최대 5로 설정했을때, 5이하인 노트만 가지고 온다
 //            let groups = fetchObjects.compactMap({ Group(managedObject: $0) })
 //            for g in groups {
 //                var resultGroup = g
@@ -25,9 +22,10 @@ class FindGroupViewModel {
 //                resultGroup.notelist = filter5underReviewcount
 //                groupDataList.append(resultGroup)
 //            }
+        } catch {
+            print(error.localizedDescription)
         }
     }
-    
 }
 
 

--- a/Bitnote/DeveloperNote/ViewModel/Group/GroupListViewModel.swift
+++ b/Bitnote/DeveloperNote/ViewModel/Group/GroupListViewModel.swift
@@ -53,7 +53,7 @@ class GroupListViewModel {
     
     
     func editGroupTitle(_ selectedGroup: Group, title: String) {
-        repository.editGroupTitle(target: selectedGroup, title: title) { [weak self] updatedGroups in
+        repository.editGroup(target: selectedGroup.id, editTitle: title) { [weak self] updatedGroups in
             if let groups = updatedGroups {
                 self?.groupListOb.accept(groups)
             }

--- a/Bitnote/DeveloperNote/ViewModel/Group/GroupListViewModel.swift
+++ b/Bitnote/DeveloperNote/ViewModel/Group/GroupListViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxRelay
 
 
-class GroupListViewModel {
+final class GroupListViewModel {
     
     private let repository: Repository
     var groupListOb = BehaviorRelay<[Group]>(value: [])


### PR DESCRIPTION
## 키워드
- `Error Handling`[^1]
- `Meta Type`[^2]
- `Realm`[^3]

## 📚 작업
- [x] RealmManager 의 realm 객체에 대한 의존성 줄이기

## 🌤 고민과 해결
`고민`
상위 객체가 하위 객체의 속성을 직접 가져와 사용하고 있으므로, 이에대한 의존성을 줄이고 객체의 책임을 나누고 싶었다.
```swift
func fetchGroups(completion: @escaping ([Group]) -> Void) {
    if let realm = RealmManager.realm() {
        let fetchObjects = realm.objects(RealmGroup.self)
        self.groupDataList = fetchObjects.compactMap({
            Group(managedObject: $0)
        })
        completion(groupDataList)
    }
}
```

`해결`
Swift 의 메타타입을 사용해 동적으로 타입을 변환했다.
1. 인자로 `Persistable Type` 을 받는다 (앱 비지니스 로직에 사용되는 Model 타입)
2. DB 에서 값의 조회를 위해 Persistable Type 을 Realm에 사용되는 타입으로 변환한다
3. 결과값인 앱 비지니스 로직에 사용되는 Model 타입으로 반환한다.

```swift
func fetchGroups(completion: @escaping ([Group]) -> Void) {
    do {
        let fetchResults = try RealmManager.fetchObjects(Group.self)
        completion(fetchResults)
    } catch {
        print(error.localizedDescription)
    }
}
```

```swift
    static func fetchObjects<T: Persistable>(_ persistable: T.Type) throws -> [T] {
        guard let realm = RealmManager.realm() else {
            throw RealmErrorMessage.FailInitialize
        }
        
        let results = realm.objects(persistable.ManagedObject)
        return results.compactMap({ T(managedObject: $0) })
    }
```


## 더 고민해보기
- RealmManager 에 책임이 더해져서 비대해질 수 있는 문제점이 있을듯 하다.
- 리펙토링을 계속 진행해보고 필요하다면 개선할 방향을 찾아보기

## ✏️ 학습한 내용
### Error 처리하기
- [Document: Error Handling](https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html)

### Meta Type
- [Document: meta type](https://docs.swift.org/swift-book/ReferenceManual/Types.html#:~:text=%E2%86%92%20some%20type-,Metatype%20Type,-A%20metatype%20type)
- [Swift의 메타타입 알아보기](https://sujinnaljin.medium.com/swift-self-type-protocol-self%EA%B0%80-%EB%AD%94%EB%94%94%EC%9A%94-7839f6aacd4)


[^1]: My reference
[^2]: 타입의 타입
[^3]: [Realm Document: Swift CURD](https://www.mongodb.com/docs/realm/sdk/swift/crud/create/)